### PR TITLE
Fix DoS vulnerabilities causing unresponsive servers

### DIFF
--- a/server/SessionManager.php
+++ b/server/SessionManager.php
@@ -168,15 +168,8 @@ class SessionManager{
 			}
 
 			$pid = ord($buffer{0});
-			if($pid == UNCONNECTED_PONG::$ID){
-				return false;
-			}
 
-			if(($packet = $this->getPacketFromPool($pid)) !== null){
-				$packet->buffer = $buffer;
-				$this->getSession($source, $port)->handlePacket($packet);
-				return true;
-			}elseif($pid === UNCONNECTED_PING::$ID){
+			if($pid === UNCONNECTED_PING::$ID){
 				//No need to create a session for just pings
 				$packet = new UNCONNECTED_PING;
 				$packet->buffer = $buffer;
@@ -187,15 +180,17 @@ class SessionManager{
 				$pk->pingID = $packet->pingID;
 				$pk->serverName = $this->getName();
 				$this->sendPacket($pk, $source, $port);
+			}elseif($pid === UNCONNECTED_PONG::$ID){
+				//ignored
+			}elseif(($packet = $this->getPacketFromPool($pid)) !== null){
+				$packet->buffer = $buffer;
+				$this->getSession($source, $port)->handlePacket($packet);
 			}else{
 				$this->streamRaw($source, $port, $buffer);
-				return true;
 			}
-		}elseif($buffer !== null){ //empty packet
-			return true;
 		}
 
-		return false;
+		return $buffer !== null;
 	}
 
 	public function sendPacket(Packet $packet, $dest, $port){

--- a/server/SessionManager.php
+++ b/server/SessionManager.php
@@ -168,7 +168,6 @@ class SessionManager{
 			}
 
 			$pid = ord($buffer{0});
-			
 			if($pid == UNCONNECTED_PONG::$ID){
 				return false;
 			}
@@ -188,12 +187,12 @@ class SessionManager{
 				$pk->pingID = $packet->pingID;
 				$pk->serverName = $this->getName();
 				$this->sendPacket($pk, $source, $port);
-			}elseif($buffer !== ""){
+			}else{
 				$this->streamRaw($source, $port, $buffer);
 				return true;
-			}else{
-				return false;
 			}
+		}elseif($buffer !== null){ //empty packet
+			return true;
 		}
 
 		return false;


### PR DESCRIPTION
DoSing a server with empty packets will currently cause the server to become unresponsive for hours, not allowing anyone to connect. The occasional client may connect successfully, but lose connection within minutes.

EDIT: Further investigation revealed that the same bug also occurs with UNCONNECTED_PING and UNCONNECTED_PONG. These vulnerabilities have also been patched.

### Explanation
The SessionManager reads packets from sockets every 20th of a second. readPacket() returns false for packets with a zero-length buffer, causing no more packets to be processed on that tick.
100,000 packets -> 100,000 ticks -> 83 minutes of downtime.

This patch fixes that by returning true for empty packets, allowing packets to continue being processed on the same tick after empty packets are processed.

### Changes
- Removed a useless empty packet check (strlen > 0 makes that redundant)
- Add empty packet check in a different place

### Tests
Tested with [Packet Generator](https://play.google.com/store/apps/details?id=packetGenrator.edu.ae) with 2000 packets @ 50 times, both before and after patch.
- Before patch: server does not respond for over an hour
- After patch: server does not respond for ~1 second (5000 packets/tick limit)