### PR TITLE
Experimental IPv6 support

### DIFF
--- a/RakLib.php
+++ b/RakLib.php
@@ -53,6 +53,7 @@ if(extension_loaded("pthreads")){
 
 if(!defined('AF_INET6')){
 	echo "[CRITICAL] This build of PHP does not support IPv6. IPv6 support is required.";
+	++$errors;
 }
 
 if($errors > 0){

--- a/RakLib.php
+++ b/RakLib.php
@@ -51,6 +51,10 @@ if(extension_loaded("pthreads")){
 	}
 }
 
+if(!defined('AF_INET6')){
+	echo "[CRITICAL] This build of PHP does not support IPv6. IPv6 support is required.";
+}
+
 if($errors > 0){
 	exit(1); //Exit with error
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-3.0",
 	"require": {
 		"php": ">=7.2.0RC3",
+		"php-ipv6": "*",
 		"ext-bcmath": "*",
 		"ext-pthreads": ">=3.1.7dev",
 		"ext-sockets": "*",

--- a/server/SessionManager.php
+++ b/server/SessionManager.php
@@ -96,7 +96,7 @@ class SessionManager{
 
 		$this->offlineMessageHandler = new OfflineMessageHandler($this);
 
-		$this->reusableAddress = new InternetAddress("0.0.0.0", 0, 4);
+		$this->reusableAddress = clone $this->socket->getBindAddress();
 
 		$this->registerPackets();
 

--- a/server/UDPServerSocket.php
+++ b/server/UDPServerSocket.php
@@ -30,6 +30,11 @@ class UDPServerSocket{
 	public function __construct(InternetAddress $bindAddress){
 		$this->bindAddress = $bindAddress;
 		$this->socket = socket_create($bindAddress->version === 4 ? AF_INET : AF_INET6, SOCK_DGRAM, SOL_UDP);
+
+		if($bindAddress->version === 6){
+			socket_set_option($this->socket, IPPROTO_IPV6, IPV6_V6ONLY, 1); //Don't map IPv4 to IPv6, the implementation can create another RakLib instance to handle IPv4
+		}
+
 		if(@socket_bind($this->socket, $bindAddress->ip, $bindAddress->port) === true){
 			socket_set_option($this->socket, SOL_SOCKET, SO_REUSEADDR, 0);
 			$this->setSendBuffer(1024 * 1024 * 8)->setRecvBuffer(1024 * 1024 * 8);

--- a/server/UDPServerSocket.php
+++ b/server/UDPServerSocket.php
@@ -29,7 +29,7 @@ class UDPServerSocket{
 
 	public function __construct(InternetAddress $bindAddress){
 		$this->bindAddress = $bindAddress;
-		$this->socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+		$this->socket = socket_create($bindAddress->version === 4 ? AF_INET : AF_INET6, SOCK_DGRAM, SOL_UDP);
 		if(@socket_bind($this->socket, $bindAddress->ip, $bindAddress->port) === true){
 			socket_set_option($this->socket, SOL_SOCKET, SO_REUSEADDR, 0);
 			$this->setSendBuffer(1024 * 1024 * 8)->setRecvBuffer(1024 * 1024 * 8);


### PR DESCRIPTION
Added support for creating a RakLib instance which binds to an IPv6 address instead of IPv4.
This closes #21 .

IPv6 address encode/decode in packets is already supported, so no further changes are needed.

There is some question about the MTU size overhead. It appears that RakNet unnecessarily accounts for headers when it doesn't need to, so it is not necessary to adjust the header size for IPv6 as I originally thought. RakNet also does not account for different header size in IPv6, so I deemed this unnecessary. We'll see how many users are hit with connection problems over IPv6.