### PR TITLE
IPv6 support for MTU

### DIFF
--- a/src/server/OfflineMessageHandler.php
+++ b/src/server/OfflineMessageHandler.php
@@ -88,7 +88,11 @@ class OfflineMessageHandler{
 				$this->sessionManager->getLogger()->notice("Refused connection from $address due to incompatible RakNet protocol version (expected $serverProtocol, got $packet->protocol)");
 			}else{
 				$pk = new OpenConnectionReply1();
-				$pk->mtuSize = $packet->mtuSize + 28; //IP header size (20 bytes) + UDP header size (8 bytes)
+				$IPHeaderSize = 20; // IPv4 header size (minimum) in bytes.
+				if($address->version === 6) {
+					$IPHeaderSize = 40; // IPv6 header size in bytes.
+				}
+				$pk->mtuSize = $packet->mtuSize + $IPHeaderSize + 8; // IP header size + UDP header size (8 bytes)
 				$pk->serverID = $this->sessionManager->getID();
 				$this->sessionManager->sendPacket($pk, $address);
 			}


### PR DESCRIPTION
The maximum transmission unit (MTU) doesn't seem correct when using an IPv6 address.

The actual MTU is based on the header size of an IPv4 address. The IPv6 header size is equal to 40 bytes (cf. https://tools.ietf.org/html/rfc2460) while the IPv4 header size has a minimum of 20 bytes and a maximum of 60 bytes.

This commit changes how the MTU is calculated. With an IPv6 address, 40 + 8 bytes (UDP header size) are added to the initial MTU. With an IPv4 address, 20 + 8 bytes are added.
