### PR TITLE
A fix for issues, caused by a wrong MTU size.

### DIFF
--- a/src/protocol/OpenConnectionReply1.php
+++ b/src/protocol/OpenConnectionReply1.php
@@ -34,6 +34,8 @@ class OpenConnectionReply1 extends OfflineMessage{
 		$this->putLong($this->serverID);
 		$this->putByte($this->serverSecurity ? 1 : 0);
 		$this->putShort($this->mtuSize);
+
+		$this->put(str_repeat("\x00", $this->mtuSize - strlen($this->buffer) - 28)); //a hack to avoid getting a wrong MTU size
 	}
 
 	protected function decodePayload() : void{


### PR DESCRIPTION
I don't how does this work, but when I've changed my router, I've noticed an issue with infinite "Building terrain..." caused by the full packet queue bigger than real client's MTU.

I've tested this a lot, and this "hack" helped. The client won't get a connection reply if it sent a wrong MTU, so it resends a request with a smaller MTU size.