### PR TITLE
Removed (string) cast in Datagram::encodePayload

### DIFF
--- a/src/protocol/Datagram.php
+++ b/src/protocol/Datagram.php
@@ -50,7 +50,7 @@ class Datagram extends Packet{
 	protected function encodePayload() : void{
 		$this->putLTriad($this->seqNumber);
 		foreach($this->packets as $packet){
-			$this->put($packet instanceof EncapsulatedPacket ? $packet->toBinary() : (string) $packet);
+			$this->put($packet instanceof EncapsulatedPacket ? $packet->toBinary() : $packet);
 		}
 	}
 


### PR DESCRIPTION
I don't see why a (string) cast would be needed. The current writes would only make it `EncapsulatedPacket|string`. If it is something else, it should allow the runtime type checking to throw an error. Casting a string would produce unreasonable valid input, e.g. an int being expressed literally in decimal form, which is apparently invalid.